### PR TITLE
nvim: use treesitter-based folding

### DIFF
--- a/nvim/.config/nvim/lua/options.lua
+++ b/nvim/.config/nvim/lua/options.lua
@@ -5,7 +5,9 @@ vim.opt.relativenumber = true -- show relative line numbers
 vim.opt.splitright = true
 vim.opt.splitbelow = true
 
-vim.opt.foldmethod = "indent"
+vim.opt.foldmethod = "expr"
+vim.opt.foldexpr = "v:lua.vim.treesitter.foldexpr()"
+vim.opt.foldtext = ""  -- preserve syntax highlighting on folded lines (Neovim 0.10+)
 vim.opt.shiftwidth = 2     -- number of spaces to use for each step of (auto)indent
 vim.opt.foldlevel = 99
 vim.opt.confirm = true     -- confirm to save changes before existing modified buffer


### PR DESCRIPTION
## Summary

Switches Neovim's fold configuration from indent-based to treesitter-based, leveraging the already-installed `nvim-treesitter` for more accurate, language-aware folding.

### Changes

- `foldmethod`: `indent` → `expr`
- `foldexpr`: `v:lua.vim.treesitter.foldexpr()` (stable API since Neovim 0.10)
- `foldtext`: `""` — preserves syntax highlighting on folded lines (Neovim 0.10+ behavior)

### Why

**Indent-based folding limitations:**
- Fails on brace-based languages (Go, Rust, C) that don't rely on indentation
- Breaks on blank lines and comments
- Doesn't recognize language constructs like Python decorators

**Treesitter-based folding benefits:**
- Language-aware: folds functions, classes, blocks based on actual AST
- Works uniformly across all languages supported by treesitter
- Zero extra cost since `nvim-treesitter` is already installed

**foldtext change:**
In Neovim 0.10+, setting `foldtext = ""` makes folded lines keep their original syntax highlighting instead of showing plain `+-- N lines: ...`. This is a free UX improvement with no extra plugins.

## Test plan

- [ ] Open a Python file, fold a function with `zc`, verify it folds correctly and preserves highlighting
- [ ] Open a Lua file (e.g. `nvim/.config/nvim/lua/plugins/lsp.lua`), fold a function, verify treesitter-based folding works
- [ ] Open a file with nested blocks, verify folds are language-accurate (not just indent-based)
- [ ] Verify `foldlevel = 99` default still keeps everything open on file open

https://claude.ai/code/session_01AMksJo2A4mdMtFwMkSuLLL