### PR TITLE
nvim: disable mason-lspconfig automatic_enable

### DIFF
--- a/nvim/.config/nvim/lua/plugins/lsp.lua
+++ b/nvim/.config/nvim/lua/plugins/lsp.lua
@@ -64,6 +64,8 @@ return {
         "ruff",
         "rust_analyzer",
       },
+      -- Disable auto-enable; vim.lsp.enable() in init.lua handles activation
+      automatic_enable = false,
     },
     config = true,
   },


### PR DESCRIPTION
## Summary

Disables `mason-lspconfig`'s `automatic_enable` so that LSP activation is handled exclusively by `vim.lsp.enable()` in `init.lua`. This clarifies the role of each component and removes the duplicate setup path.

### Role split after this change

| Component | Role |
|---|---|
| `mason.nvim` | Install LSP binaries |
| `mason-lspconfig` | `ensure_installed` (install-only) |
| `nvim-lspconfig` | Provide default server configs (cmd, filetypes, root_markers) |
| `vim.lsp.enable()` + `lsp/*.lua` | Activate and configure servers (Neovim 0.11+ native API) |

### Why

The repo already uses the Neovim 0.11+ native pattern:

- `init.lua` calls `vim.lsp.enable({...})`
- Per-server configs live under `lsp/*.lua` (auto-discovered by Neovim)

But `mason-lspconfig` was also running its own auto-setup path via `config = true`, which duplicates LSP activation. Setting `automatic_enable = false` makes `mason-lspconfig` install-only, removing the ambiguity.

## Test plan

- [ ] Neovim restart — LSP servers still attach to supported filetypes
- [ ] `:checkhealth lsp` shows expected servers running
- [ ] Clean install / new machine — `ensure_installed` servers still auto-install via mason
- [ ] Diagnostics, completion, and go-to-definition work as before

https://claude.ai/code/session_01AMksJo2A4mdMtFwMkSuLLL