### PR TITLE
nvim: remove vim-unimpaired

### DIFF
--- a/nvim/.config/nvim/lua/plugins/tpope.lua
+++ b/nvim/.config/nvim/lua/plugins/tpope.lua
@@ -10,11 +10,6 @@ return {
   },
 
   {
-    "tpope/vim-unimpaired",
-    lazy = false,
-  },
-
-  {
     "tpope/vim-eunuch",
     lazy = false,
   },


### PR DESCRIPTION
## Summary

Removes `tpope/vim-unimpaired` from the plugin list. Neovim 0.11 added native default mappings that cover the majority of the bracket-pair navigation provided by unimpaired.

## Built-in replacements (Neovim 0.11+)

These mappings are now provided natively and no longer need unimpaired:

### Navigation

| Mapping | Action |
|---|---|
| `[d` / `]d` | Previous / next diagnostic |
| `[D` / `]D` | First / last diagnostic in buffer |
| `[q` / `]q` | Previous / next quickfix item |
| `[Q` / `]Q` | First / last quickfix item |
| `[l` / `]l` | Previous / next location list item |
| `[L` / `]L` | First / last location list item |
| `[b` / `]b` | Previous / next buffer |
| `[B` / `]B` | First / last buffer |
| `[t` / `]t` | Previous / next tag stack entry |
| `[T` / `]T` | First / last tag stack entry |
| `[a` / `]a` | Previous / next arglist entry |
| `[A` / `]A` | First / last arglist entry |

### Editing

| Mapping | Action |
|---|---|
| `[<Space>` | Add blank line above |
| `]<Space>` | Add blank line below |

## Features NOT covered by built-ins

If any of these are in muscle memory, they will break:

- `[e` / `]e` — move line up / down
- `[p` / `]p` — paste with auto-indent
- Option toggles: `cos` (spell), `cow` (wrap), `con` (number), `cor` (relative), `coh` (hlsearch), `coc` (cursorline), `col` (list)
- Encoding: `[xx` / `]xx` (XML), `[uu` / `]uu` (URL), `[yy` / `]yy` (C-string)
- Directory navigation: `[f` / `]f` (same-directory file cycling)

These can be added back as manual keymaps in `keymaps.lua` if needed.

## Test plan

- [ ] `[d` / `]d` — diagnostic jumps still work (already overridden in `lsp.lua` via `vim.diagnostic.jump()`)
- [ ] `[q` / `]q` — open a quickfix list (`:copen`), cycle through entries
- [ ] `[b` / `]b` — buffer navigation still works
- [ ] `[<Space>` / `]<Space>` — blank line insertion still works
- [ ] Check for any Lua errors on startup (plugin cleanly removed)

https://claude.ai/code/session_01AMksJo2A4mdMtFwMkSuLLL