### PR TITLE
cc-edit: open last CC response alongside Ctrl-G editor

### DIFF
--- a/my-plugins/hooks/hooks.json
+++ b/my-plugins/hooks/hooks.json
@@ -7,6 +7,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/tmux-status.sh SessionStart",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/cc-edit-context.sh",
+            "timeout": 5
           }
         ]
       }

--- a/my-plugins/hooks/scripts/cc-edit-context.sh
+++ b/my-plugins/hooks/scripts/cc-edit-context.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Record the current session's transcript path to a TTY-keyed registry so that
+# nvim (invoked via Ctrl-G → $EDITOR on a claude-prompt-*.md tempfile) can load
+# the last assistant response alongside the prompt draft.
+#
+# Fires on SessionStart. Overwrites on /clear, /resume, /compact — all of which
+# re-fire SessionStart with a different source.
+set -u
+
+# Walk up the process tree to find the first ancestor with a real controlling
+# tty. In most cases this is the immediate parent (Claude Code); we walk up
+# just in case stdin/stdout are piped and a direct `ps -o tty= -p $$` returns
+# `??`.
+tty=""
+pid=$$
+while [ -n "$pid" ] && [ "$pid" != "1" ] && [ "$pid" != "0" ]; do
+  t=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' /')
+  if [ -n "$t" ] && [ "$t" != "??" ]; then
+    tty="$t"
+    break
+  fi
+  pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+done
+[ -n "$tty" ] || exit 0
+
+out_dir="${TMPDIR:-/tmp}"
+out_dir="${out_dir%/}/cc-edit-context"
+mkdir -p "$out_dir" 2>/dev/null || exit 0
+
+jq -c '{transcript_path, session_id, cwd}' \
+  > "${out_dir}/${tty}.json" 2>/dev/null || exit 0

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -1,6 +1,7 @@
 require("keymaps")
 require("bootstrap")
 require("options")
+require("cc-edit")
 
 vim.lsp.enable({
   "lua_ls",

--- a/nvim/.config/nvim/lua/cc-edit/init.lua
+++ b/nvim/.config/nvim/lua/cc-edit/init.lua
@@ -1,0 +1,125 @@
+-- cc-edit: When Claude Code opens $EDITOR on Ctrl-G (tempfile matching
+-- claude-prompt-*.md), open the last assistant response in a read-only split
+-- beside the prompt draft.
+--
+-- Pairs with the SessionStart hook at:
+--   my-plugins/hooks/scripts/cc-edit-context.sh
+-- which records transcript_path to a TTY-keyed registry file.
+--
+-- Configure by calling setup with options, e.g.:
+--   require('cc-edit').setup({ ratio = 0.7 })
+
+local M = {}
+
+M.config = {
+  -- Width of the response pane as a fraction of total columns (0..1).
+  ratio = 0.5,
+}
+
+local function current_tty()
+  -- Walk up the process tree to find an ancestor with a real tty.
+  -- Mirrors the logic in cc-edit-context.sh so both sides resolve the
+  -- same registry key.
+  local pid = vim.fn.getpid()
+  while pid and pid ~= 0 and pid ~= 1 do
+    local t = vim.fn.system('ps -o tty= -p ' .. pid):gsub('[%s/]', '')
+    if t ~= '' and t ~= '??' then
+      return t
+    end
+    local ppid = vim.fn.system('ps -o ppid= -p ' .. pid):gsub('%s', '')
+    pid = tonumber(ppid)
+  end
+  return nil
+end
+
+local function registry_path(tty)
+  local tmpdir = vim.env.TMPDIR or '/tmp'
+  if not tmpdir:match('/$') then tmpdir = tmpdir .. '/' end
+  return tmpdir .. 'cc-edit-context/' .. tty .. '.json'
+end
+
+local function load_context()
+  -- Note: CLAUDECODE env is NOT propagated to the EDITOR child spawned by
+  -- Ctrl-G (CC scrubs it via CLAUDE_CODE_SUBPROCESS_ENV_SCRUB). The combo of
+  -- the claude-prompt-*.md autocmd pattern plus a registry hit is specific
+  -- enough to avoid false positives.
+  local tty = current_tty()
+  if not tty then return nil end
+
+  local reg = registry_path(tty)
+  if vim.fn.filereadable(reg) == 0 then return nil end
+
+  local raw = vim.fn.readfile(reg)[1]
+  if not raw or raw == '' then return nil end
+  local ok, ctx = pcall(vim.json.decode, raw)
+  if not ok then return nil end
+  return ctx
+end
+
+-- Extract the last assistant text block. Walks backward from EOF, returns
+-- the last `text` block from the most recent `type:"assistant"` entry that
+-- has one.
+local function extract_last_response(transcript_path)
+  if not transcript_path or vim.fn.filereadable(transcript_path) == 0 then
+    return nil
+  end
+  local lines = vim.fn.readfile(transcript_path)
+  for i = #lines, 1, -1 do
+    local ok, e = pcall(vim.json.decode, lines[i])
+    if ok and type(e) == 'table' and e.type == 'assistant'
+       and type(e.message) == 'table'
+       and type(e.message.content) == 'table' then
+      local last_text
+      for _, b in ipairs(e.message.content) do
+        if type(b) == 'table' and b.type == 'text'
+           and type(b.text) == 'string' and b.text ~= '' then
+          last_text = b.text
+        end
+      end
+      if last_text then return last_text end
+    end
+  end
+  return nil
+end
+
+local function open_context_layout()
+  local ctx = load_context()
+  if not ctx then return end
+
+  local text = extract_last_response(ctx.transcript_path)
+  if not text then return end
+
+  local resp_path = vim.fn.stdpath('cache') .. '/cc-last-response.md'
+  vim.fn.writefile(vim.split(text, '\n', { plain = true }), resp_path)
+
+  local prompt_win = vim.api.nvim_get_current_win()
+
+  vim.cmd('topleft vsplit ' .. vim.fn.fnameescape(resp_path))
+  vim.cmd('vertical resize ' .. math.floor(vim.o.columns * M.config.ratio))
+  vim.bo.filetype = 'markdown'
+  vim.bo.modifiable = false
+  vim.bo.readonly = true
+  vim.bo.buflisted = false
+  vim.bo.swapfile = false
+
+  if vim.api.nvim_win_is_valid(prompt_win) then
+    vim.api.nvim_set_current_win(prompt_win)
+  end
+end
+
+function M.setup(opts)
+  if opts then
+    M.config = vim.tbl_deep_extend('force', M.config, opts)
+  end
+  local group = vim.api.nvim_create_augroup('cc-edit', { clear = true })
+  vim.api.nvim_create_autocmd('BufReadPost', {
+    group = group,
+    pattern = '*claude-prompt-*.md',
+    callback = function()
+      vim.schedule(open_context_layout)
+    end,
+  })
+end
+
+M.setup()
+return M


### PR DESCRIPTION
## Summary
- **Problem**: Ctrl-G in Claude Code opens a blank external editor — the last AI response is out of sight while composing the next prompt, so you can't easily reference, copy, or verify against it.
- **Solution**: An nvim split that shows the last assistant response (read-only, 5:5 default) beside the prompt draft, auto-triggered when nvim opens CC's `claude-prompt-*.md` tempfile.
- **Shape**: SessionStart hook drops transcript path into a TTY-keyed registry; nvim autocmd reads the registry, extracts the last assistant text block, and sets up the split.

## Why this shape
- **Hybrid (CC plugin + nvim plugin)**: CC has no IPC to tell a child process its session id, so a hook is the only bridge. Hook records the session anchor, nvim owns the UI.
- **TTY as registry key**: Avoids PID walking and SessionEnd cleanup entirely — each tmux pane has a unique pty so concurrent CC sessions (I usually have 6+ running) don't collide.
- **No shell wrapper**: Keeps `EDITOR=nvim` untouched. One fewer layer, markdown highlighting is free, works outside tmux too.
- **Last `text` block only**: A completed assistant turn ends in `thinking → tool_use* → thinking → text`; the final `text` is the canonical response. Middle text blocks are narration fragments.

## Files
- `my-plugins/hooks/scripts/cc-edit-context.sh` — 15-line bash, pipes SessionStart payload through jq to registry file keyed by walk-up tty.
- `my-plugins/hooks/hooks.json` — registers the new hook alongside existing tmux-status one.
- `nvim/.config/nvim/lua/cc-edit/init.lua` — autocmd + layout logic + `M.config.ratio` + `setup(opts)`.
- `nvim/.config/nvim/init.lua` — `require("cc-edit")`.

## Configuration
Default 5:5 split. Override with:
```lua
require("cc-edit").setup({ ratio = 0.7 })
```

## Test plan
- [x] Hook script unit: mock SessionStart payload on stdin → registry file created with correct JSON.
- [x] Lua extraction: real transcript jsonl → last assistant text block correctly extracted.
- [x] E2E headless: fake `claude-prompt-*.md` + nvim → 2 windows, correct ratio, response readonly, cursor in prompt.
- [x] **Real tmux E2E**: fresh `claude` session, send "hi", wait for response, press Ctrl-G → split appears with response text on the left.
- [x] Reinstall via `/plugin` after merge so other CC sessions pick up the new hook (cache sync).

## Known fragilities (worth knowing later)
- **`claude-prompt-*.md` naming is locked to CC version.** If CC changes the tempfile naming on upgrade, the autocmd silently stops firing. Diagnostic: registry file exists but no split.
- **Hook failures are silent** (`exit 0`). First diagnostic on breakage: check `$TMPDIR/cc-edit-context/<tty>.json`.
- **CC scrubs `CLAUDECODE` env from the EDITOR child** (`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`) — learned this during debugging. Don't rely on it in EDITOR-side code.
- **macOS-specific**: `ps -o tty=` format, `/private/tmp` symlink, `TMPDIR` path assumptions. Linux port would need verification.

## Extension hooks
Designed to grow via a provider pattern. Future candidates:
- Plan file (`~/.claude/plans/*.md` latest)
- `git diff` in `ctx.cwd`
- Memory file
- N previous turns

Multiple context sources would attach as buffers to the left window and cycle via `:bn`/`:bp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)