### PR TITLE
cc-edit: use in-memory buffer to avoid multi-session collision

### DIFF
--- a/nvim/.config/nvim/lua/cc-edit/init.lua
+++ b/nvim/.config/nvim/lua/cc-edit/init.lua
@@ -89,18 +89,24 @@ local function open_context_layout()
   local text = extract_last_response(ctx.transcript_path)
   if not text then return end
 
-  local resp_path = vim.fn.stdpath('cache') .. '/cc-last-response.md'
-  vim.fn.writefile(vim.split(text, '\n', { plain = true }), resp_path)
-
   local prompt_win = vim.api.nvim_get_current_win()
 
-  vim.cmd('topleft vsplit ' .. vim.fn.fnameescape(resp_path))
+  -- Create an empty vsplit on the far left, then populate its (new, unnamed)
+  -- buffer with the response. Uses an in-memory scratch buffer — no file is
+  -- written to disk, so concurrent CC sessions never share state (no swap
+  -- collision, no undofile interleaving, no content races).
+  vim.cmd('topleft vnew')
+  local buf = vim.api.nvim_get_current_buf()
+  vim.bo[buf].buftype = 'nofile'
+  vim.bo[buf].bufhidden = 'wipe'
+  vim.bo[buf].swapfile = false
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(text, '\n', { plain = true }))
+  vim.bo[buf].filetype = 'markdown'
+  vim.bo[buf].modifiable = false
+  vim.bo[buf].readonly = true
+  pcall(vim.api.nvim_buf_set_name, buf, 'cc-last-response')
+
   vim.cmd('vertical resize ' .. math.floor(vim.o.columns * M.config.ratio))
-  vim.bo.filetype = 'markdown'
-  vim.bo.modifiable = false
-  vim.bo.readonly = true
-  vim.bo.buflisted = false
-  vim.bo.swapfile = false
 
   if vim.api.nvim_win_is_valid(prompt_win) then
     vim.api.nvim_set_current_win(prompt_win)


### PR DESCRIPTION
## Summary
Follow-up fix for #7. The plugin wrote the last response to `~/.cache/nvim/cc-last-response.md` — a single shared path used by every nvim instance spawned via Ctrl-G. With concurrent Claude Code sessions, this caused the symptom the user observed: content from one session appearing to "overwrite" another.

## Root cause (what went wrong)

`nvim/.config/nvim/lua/cc-edit/init.lua:92-93` (pre-fix):
```lua
local resp_path = vim.fn.stdpath('cache') .. '/cc-last-response.md'
vim.fn.writefile(..., resp_path)
```

Three concrete problems compounded:

1. **Swap file collision** — nvim creates `.cc-last-response.md.swp` per buffer at load time. A second nvim opening the same file triggers `ATTENTION: Found a swap file` and weird interactive behavior.
2. **Undofile interleaving** — `options.lua:1` has `undofile = true`, so undo history for `cc-last-response.md` was shared/interleaved between instances.
3. **Content race** — if any reload mechanism fires in nvim#1 (autoread, FocusGained/BufEnter checktime, `:e`, plugin-triggered reload) after nvim#2 overwrites the file, nvim#1 suddenly displays the wrong session's response.

## Fix

Replace the on-disk file with an **in-memory scratch buffer**:

- `buftype = 'nofile'` — not associated with any file on disk
- `bufhidden = 'wipe'` — buffer is deleted when its last window closes; no leak
- `swapfile = false` — explicit, though nofile buffers skip swap anyway

Each nvim process owns its own buffer in its own memory; nothing is written to disk, so concurrent CC sessions are structurally incapable of sharing state.

**Visible layout, `M.config.ratio`, and `setup({...})` API are unchanged.**

## Test plan
- [x] Headless regression: scratch buffer verified (`buftype=nofile`, `bufhidden=wipe`, readonly, markdown, correct ratio, cursor in prompt).
- [x] No disk artifact: `cc-last-response.md exists? false` after running the autocmd.
- [x] No files under `~/.cache/nvim/cc-last-response*` after the test run.
- [ ] Real multi-CC tmux E2E (after merge): two `claude` sessions, Ctrl-G in each, verify each shows its own response; leave both nvim instances open concurrently and confirm no swap warning / no content swap.

## Migration note
Users who have already run the previous version should delete the leftover file (safe even if missing):
```bash
rm -f ~/.cache/nvim/cc-last-response.md
```

Already done on my machine as part of implementing this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)