### PR TITLE
nvim: add markview.nvim for in-buffer markdown rendering

### DIFF
--- a/nvim/.config/nvim/lua/plugins/lang/markdown.lua
+++ b/nvim/.config/nvim/lua/plugins/lang/markdown.lua
@@ -8,4 +8,12 @@ return {
     end,
     ft = { "markdown" },
   },
+  {
+    "OXY2DEV/markview.nvim",
+    ft = { "markdown" },
+    dependencies = {
+      "nvim-treesitter/nvim-treesitter",
+      "nvim-tree/nvim-web-devicons",
+    },
+  },
 }


### PR DESCRIPTION
## Summary
- `markview.nvim`을 markdown 플러그인 파일에 추가해 nvim 버퍼 안에서 헤딩/코드블록/체크박스/테이블/콜아웃을 이쁘게 렌더링
- 기존 `markdown-preview.nvim`(브라우저 프리뷰)은 그대로 유지 — 용도 다름 (긴 문서 풀 프리뷰)
- `ft = { "markdown" }`로 lazy load. blink.cmp 의존성은 우리 환경에 없어서 제외, web-devicons만 명시

## Test plan
- [ ] `nvim some.md` 열어서 헤딩 아이콘/코드블록 배경 렌더링 확인
- [ ] `:Markview Toggle`로 raw ↔ rendered 전환
- [ ] `:Markview HybridToggle`로 커서 줄만 raw로 보이는지 확인
- [ ] 기존 `:MarkdownPreview` 명령 정상 동작하는지 확인 (충돌 없음)

https://claude.ai/code/session_01TRbVq4rjRN3MUoihz3m4s2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRbVq4rjRN3MUoihz3m4s2)_