### PR TITLE
my-plugins: add grill-me skill

### DIFF
--- a/my-plugins/skills/grill-me/SKILL.md
+++ b/my-plugins/skills/grill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.


### PR DESCRIPTION
## Summary
- Add `grill-me` skill to `my-plugins` at `my-plugins/skills/grill-me/SKILL.md`
- Verbatim copy from [mattpocock/skills](https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md): interviews the user relentlessly about a plan/design, walking each branch of the decision tree one question at a time

## Test plan
- [ ] Reload Claude Code and verify the `grill-me` skill is discoverable
- [ ] Trigger via "grill me" and confirm it asks one question at a time with recommended answers

https://claude.ai/code/session_01NtpaUvq2qwpqqYCSY1otRg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtpaUvq2qwpqqYCSY1otRg)_