### PR TITLE
tmux: rebind window swap to &lt; and &gt;

### DIFF
--- a/tmux/.tmux.conf.local
+++ b/tmux/.tmux.conf.local
@@ -316,8 +316,8 @@ bind-key -r C-u last-window
 bind-key -r C-o run-shell '$HOME/scripts/swap-tmux-pane.sh'
 
 # Window swapping shortcuts
-bind -r "<" swap-window -d -t -1  # Move current window left
-bind -r ">" swap-window -d -t +1  # Move current window right
+bind -r "<" swap-window -t -1  # Move current window left
+bind -r ">" swap-window -t +1  # Move current window right
 bind W choose-window "swap-window -t %%"  # Interactive window swapping
 bind M-w command-prompt -p "move window to:" "move-window -t %%"  # Move to specific position
 

--- a/tmux/.tmux.conf.local
+++ b/tmux/.tmux.conf.local
@@ -316,8 +316,8 @@ bind-key -r C-u last-window
 bind-key -r C-o run-shell '$HOME/scripts/swap-tmux-pane.sh'
 
 # Window swapping shortcuts
-bind -r M swap-window -t -1  # Move current window left
-bind -r m swap-window -t +1  # Move current window right
+bind -r "<" swap-window -d -t -1  # Move current window left
+bind -r ">" swap-window -d -t +1  # Move current window right
 bind W choose-window "swap-window -t %%"  # Interactive window swapping
 bind M-w command-prompt -p "move window to:" "move-window -t %%"  # Move to specific position
 


### PR DESCRIPTION
## Summary
- Rebind window swap keys in `tmux/.tmux.conf.local` from `M`/`m` to `<`/`>` for `swap-window -t -1` / `+1`.

## Test plan
- [ ] Reload tmux config and verify `prefix + <` moves the current window left
- [ ] Verify `prefix + >` moves the current window right
- [ ] Confirm repeat (`-r`) still works for consecutive presses

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqaSeTuSRKcLm76R6HmmZm)_